### PR TITLE
Change i2c status feature report read length to 61.

### DIFF
--- a/ft260/__init__.py
+++ b/ft260/__init__.py
@@ -395,6 +395,30 @@ class FT260_I2C():
 
         payload = [register] + list(value)
         self._write_i2c(address, payload)
+
+    def i2c_rdwr(self, *msgs):
+        for i, msg in enumerate(msgs):
+            last = i == len(msgs) - 1
+            first = i == 0
+            if first and last:
+                flags = 0x06 # start+stop
+            elif first:
+                flags = 0x02 # start only
+            elif last:
+                flags = 0x07 # stop only
+            else:
+                flags = 0x03 # repeated start
+            if msg.flags & 0x0001: # read
+                response = self._read_i2c(msg.addr, msg.len, flags)
+                for i in range(msg.len):
+                    msg.buf[i] = response[i]
+            else:
+                buf = []
+                for i in range(msg.len):
+                    buf.append(msg.buf[i][0])
+                self._write_i2c(msg.addr, buf, flags)
+
+
     
 
 class FT260():

--- a/ft260/__init__.py
+++ b/ft260/__init__.py
@@ -132,7 +132,7 @@ class FT260_I2C():
 
     def get_i2c_status(self):
         """Query I2C engine status and current baudrate."""
-        d = self.device.get_feature_report(0xC0, 5)
+        d = self.device.get_feature_report(0xC0, 61)
         bus = d[1]
         status = {
             "busy_chip":        (bus >> 0) & 1,


### PR DESCRIPTION
Even though it's only 5 bytes, the hid report descriptor says 60 bytes (plus report id)
Fixes #5 